### PR TITLE
Refactor: Centralize FlexDaemonsetTemplateAnnotation and update predicate

### DIFF
--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	PodApplyTemplateAnnotation      = "flexdaemonsets.xai/apply-template"    // From webhook
-	FlexDaemonsetTemplateAnnotation = "flexdaemonsets.xai/resource-template" // On DaemonSet
+	PodApplyTemplateAnnotation = "flexdaemonsets.xai/apply-template" // From webhook
 )
 
 // PodReconciler reconciles a Pod object

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,0 +1,3 @@
+package utils
+
+const FlexDaemonsetTemplateAnnotation = "flexdaemonsets.xai/resource-template"

--- a/pkg/webhook/mutator.go
+++ b/pkg/webhook/mutator.go
@@ -14,12 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	// flexdaemonsetsv1alpha1 "github.com/prakarsh-dt/FlexDaemonsets/pkg/apis/flexdaemonsets/v1alpha1" // Removed
-	// utils "github.com/prakarsh-dt/FlexDaemonsets/pkg/utils" // Removed
+	"github.com/prakarsh-dt/FlexDaemonsets/pkg/utils"
 )
 
 const (
-	FlexDaemonsetTemplateAnnotation = "flexdaemonsets.xai/resource-template" // Annotation on DaemonSet
-	PodApplyTemplateAnnotation      = "flexdaemonsets.xai/apply-template"    // Annotation to be placed on Pod
+	PodApplyTemplateAnnotation = "flexdaemonsets.xai/apply-template" // Annotation to be placed on Pod
 )
 
 var log = ctrl.Log.WithName("webhook").WithName("PodMutator")
@@ -81,9 +80,9 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 	requestLogger.Info("Successfully fetched owning DaemonSet", "daemonSetName", daemonSetName)
 
 	// Read annotation from DaemonSet
-	templateNameFromDSAnnotation, ok := daemonSet.Annotations[FlexDaemonsetTemplateAnnotation]
+	templateNameFromDSAnnotation, ok := daemonSet.Annotations[utils.FlexDaemonsetTemplateAnnotation]
 	if !ok || templateNameFromDSAnnotation == "" {
-		requestLogger.Info("Owning DaemonSet does not have the required annotation or annotation is empty.", "daemonSetName", daemonSetName, "annotation", FlexDaemonsetTemplateAnnotation)
+		requestLogger.Info("Owning DaemonSet does not have the required annotation or annotation is empty.", "daemonSetName", daemonSetName, "annotation", utils.FlexDaemonsetTemplateAnnotation)
 		return admission.Allowed("Owning DaemonSet is not annotated for flex resource allocation.")
 	}
 	requestLogger.Info("Found template annotation on DaemonSet", "templateName", templateNameFromDSAnnotation)


### PR DESCRIPTION


I centralized FlexDaemonsetTemplateAnnotation into pkg/utils/constants.go. I also updated pod_controller.go, nodecoverage_controller.go, and pkg/webhook/mutator.go to use the constant from pkg/utils.

In nodecoverage_controller.go, I modified the AnnotationChangedPredicate in SetupWithManager to predicate.AnnotationChangedPredicate{} to react to any annotation change on DaemonSets. The specific filtering for FlexDaemonsetTemplateAnnotation will occur within the Reconcile loop.